### PR TITLE
Possible fix for OOM exception

### DIFF
--- a/deps.gradle
+++ b/deps.gradle
@@ -37,7 +37,7 @@ dependencies {
         COMMONS_RNG_LIB = "org.apache.commons:commons-rng-simple:1.3"
 
         // Janelia libraries
-        JACS_MODEL_VERSION = "3.3.5"
+        JACS_MODEL_VERSION = "3.3.6"
         JACS_MODEL_RENDERING_LIB = "org.janelia.jacs-model:jacs-model-rendering:${JACS_MODEL_VERSION}"
 
         // JAX-RS API

--- a/jacsstorage-services/src/main/java/org/janelia/jacsstorage/service/impl/FileSystemStorageService.java
+++ b/jacsstorage-services/src/main/java/org/janelia/jacsstorage/service/impl/FileSystemStorageService.java
@@ -27,6 +27,7 @@ import org.janelia.jacsstorage.service.ContentNode;
 import org.janelia.jacsstorage.service.ContentStorageService;
 import org.janelia.jacsstorage.service.NoContentFoundException;
 import org.janelia.jacsstorage.service.StorageCapacity;
+import org.janelia.rendering.utils.ImageUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,11 +133,7 @@ public class FileSystemStorageService implements ContentStorageService {
 
         if (Files.exists(contentPath)) {
             if (Files.isRegularFile(contentPath)) {
-                try {
-                    return Files.newInputStream(contentPath);
-                } catch (IOException e) {
-                    throw new ContentException(e);
-                }
+                return ImageUtils.openSeekableStream(contentPath);
             } else {
                 throw new ContentException("Content found at " + contentLocation + " is not a regular file");
             }


### PR DESCRIPTION
Before adding support for S3URI all file streams were opened using SeekableStream and this is may be a regression because now when a 2D slice is retrieved - the entire tiff is loaded in memory - if there are 2 channels - will be 2 tiffs. Before because everything was a seekable stream the channel blending only had to seek to the proper slice. Also because we were using seekable stream we didn't have the TooManyFiles opened problem